### PR TITLE
REI Compat update + Recipe Fix

### DIFF
--- a/src/main/java/com/chefsdelights/farmersrespite/integration/rei/category/BrewingRecipeCategory.java
+++ b/src/main/java/com/chefsdelights/farmersrespite/integration/rei/category/BrewingRecipeCategory.java
@@ -55,7 +55,12 @@ public class BrewingRecipeCategory implements DisplayCategory<BrewingRecipeDispl
         
 		if(display.getNeedWater() == true){
 			widgets.add(Widgets.createTexturedWidget(GUI_TEXTURE, new Rectangle(bgBounds.x + 5, bgBounds.y + 23, 5, 11), 176.0F, 15.0F));
+			widgets.add(Widgets.createLabel(new Point(bgBounds.x + 5, bgBounds.y + 23), Component.literal(" ")).noShadow().leftAligned().tooltip(FarmersRespite.i18n("rei.brewing.needWater")));
 		}
+		else{
+			widgets.add(Widgets.createLabel(new Point(bgBounds.x + 5, bgBounds.y + 23), Component.literal(" ")).noShadow().tooltip(FarmersRespite.i18n("rei.brewing.noWater")));
+		}
+		
 		widgets.add(Widgets.createSlot(new Point(bgBounds.x + 57, bgBounds.y + 39)).entries(display.getContainerOutput()).markInput().disableBackground());
 		widgets.add(Widgets.createSlot(new Point(bgBounds.x + 89, bgBounds.y + 12)).entries(display.getOutputEntries().get(0)).markOutput().disableBackground());
 		widgets.add(Widgets.createSlot(new Point(bgBounds.x + 89, bgBounds.y + 39)).entries(display.getOutputEntries().get(0)).markOutput().disableBackground());

--- a/src/main/resources/assets/farmersrespite/lang/en_us.json
+++ b/src/main/resources/assets/farmersrespite/lang/en_us.json
@@ -1,10 +1,43 @@
 {
   "block.farmersrespite.kettle": "Kettle",
+  
   "block.farmersrespite.rose_hip_pie": "Rose Hip Pie",
   "block.farmersrespite.coffee_cake": "Coffee Cake",
+  
   "block.farmersrespite.small_tea_bush": "Tea Seeds",
-  "block.farmersrespite.coffee_bush": "Coffee Beans",
   "block.farmersrespite.wild_tea_bush": "Wild Tea Bush",
+  "block.farmersrespite.tea_bush": "Tea Bush",
+  
+  "block.farmersrespite.coffee_bush": "Coffee Beans",
+  "block.farmersrespite.coffee_bush_top": "Coffee Bush",
+  "block.farmersrespite.coffee_stem": "Coffee Stem",
+  "block.farmersrespite.coffee_stem_double": "Coffee Stem",
+  "block.farmersrespite.coffee_stem_middle": "Coffee Stem",
+  
+  "block.farmersrespite.candle_coffee_cake": "Candle Coffee Cake",
+  "block.farmersrespite.white_candle_coffee_cake": "White Candle Coffee Cake",
+  "block.farmersrespite.orange_candle_coffee_cake": "Orange Candle Coffee Cake",
+  "block.farmersrespite.magenta_candle_coffee_cake": "Magenta Candle Coffee Cake",
+  "block.farmersrespite.light_blue_candle_coffee_cake": "Light Blue Candle Coffee Cake",
+  "block.farmersrespite.yellow_candle_coffee_cake": "Yellow Candle Coffee Cake",
+  "block.farmersrespite.lime_candle_coffee_cake": "Lime Candle Coffee Cake",
+  "block.farmersrespite.pink_candle_coffee_cake": "Pink Candle Coffee Cake",
+  "block.farmersrespite.gray_candle_coffee_cake": "Gray Candle Coffee Cake",
+  "block.farmersrespite.light_gray_candle_coffee_cake": "Light Gray Candle Coffee Cake",
+  "block.farmersrespite.cyan_candle_coffee_cake": "Cyan Candle Coffee Cake",
+  "block.farmersrespite.purple_candle_coffee_cake": "Purple Candle Coffee Cake",
+  "block.farmersrespite.blue_candle_coffee_cake": "Blue Candle Coffee Cake",
+  "block.farmersrespite.brown_candle_coffee_cake": "Brown Candle Coffee Cake",
+  "block.farmersrespite.green_candle_coffee_cake": "Green Candle Coffee Cake",
+  "block.farmersrespite.red_candle_coffee_cake": "Red Candle Coffee Cake",
+  "block.farmersrespite.black_candle_coffee_cake": "Black Candle Coffee Cake",
+  
+  "block.farmersrespite.potted_coffee_bush": "Potted Coffee Bush",
+  "block.farmersrespite.potted_tea_bush": "Potted Tea Bush",
+  "block.farmersrespite.potted_wild_tea_bush": "Potted Wild Tea Bush",
+  
+  "block.farmersrespite.wither_roots": "Wither Roots",
+  "block.farmersrespite.wither_roots_plant": "Wither Roots Plant",
 
   "item.farmersrespite.green_tea_leaves": "Green Tea Leaves",
   "item.farmersrespite.yellow_tea_leaves": "Yellow Tea Leaves",
@@ -66,6 +99,8 @@
   "effect.farmersrespite.caffeinated": "Caffeinated",
 
   "farmersrespite.rei.brewing": "Brewing",
+  "farmersrespite.rei.brewing.noWater": "No water required",
+  "farmersrespite.rei.brewing.needWater": "Requires 1 glass of water",
 
   "itemGroup.farmersrespite.group": "Farmer's Respite"
 

--- a/src/main/resources/data/farmersrespite/recipes/black_cod.json
+++ b/src/main/resources/data/farmersrespite/recipes/black_cod.json
@@ -14,7 +14,7 @@
       "tag": "c:crops/cabbage"
     },
     {
-      "tag": "c:crops/rice"
+      "item": "farmersdelight:cooked_rice"
     }
   ],
   "result": {


### PR DESCRIPTION
## ● Reworked **Black Cod** recipe to accept **Cooked Rice** instead of **Raw Rice**
 
## ● Added hover tooltips to the Brewing's REI GUI water indicator
![2023-01-22_16 10 18](https://user-images.githubusercontent.com/114457180/213906890-1420e609-b23a-4372-959f-851e51ec1e22.png)
 It uses the language file in favor of translators

## ● Updated language file 
1. Ported https://github.com/Chefs-Delight/Farmersrespite-Fabric/pull/4/commits/ecbe3fd8cabbaf2d37c26082d4304b7e6aaa6c56 to 1.19
2. Added entries for REI Compat stuffs
